### PR TITLE
Fix some hot reload issues

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -10,7 +10,6 @@ var config = {
    * efficiently build out the application's dependency tree.
    */
   entry: [
-      "react-hot-loader/patch",
       "webpack-dev-server/client?http://localhost:3000",
       "webpack/hot/only-dev-server",
       "./src/index.tsx"],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "node server.js"
   },
   "devDependencies": {
-    "react-hot-loader": "^3.0.0-beta.2",
     "ts-loader": "^2.0.0",
     "typescript": "^2.1.5",
     "typings": "^2.1.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,24 +1,8 @@
 import * as React from 'react'
-
-import { todoStore,  ObservableTodoStore} from '../state/todos.state';
 import { TodoList } from './todolist.component';
 
-class App extends React.Component<any, any> {
-    constructor(props: any) {
-        super(props);
-    }
-
+class App extends React.Component<{}, {}> {
     render() {
-        todoStore.addTodo("read MobX tutorial");
-
-        todoStore.addTodo("try MobX");
-
-        todoStore.todos[0].completed = true;
-
-        todoStore.todos[1].task = "try MobX in own project";
-
-        todoStore.todos[0].task = "grok MobX tutorial";
-
         return (
             <TodoList />
         );

--- a/src/components/counter.component.tsx
+++ b/src/components/counter.component.tsx
@@ -3,14 +3,13 @@ import { observer, inject } from 'mobx-react';
 
 import { Counter } from '../state/counter.state';
 
+interface Props {
+    counter: Counter;
+}
 @observer
-class RenderCounter extends React.Component<any, any> {
-    constructor(props : any) {
-        super(props);
-    }
-
+class RenderCounter extends React.Component<Props, {}> {
     render() {
-        const counter: Counter = this.props.counter;
+        const counter = this.props.counter;
         return (
             <div>{counter.count}</div>
         );

--- a/src/components/todolist.component.tsx
+++ b/src/components/todolist.component.tsx
@@ -3,20 +3,18 @@ import { observer, inject } from 'mobx-react';
 import Devtools from 'mobx-react-devtools';
 
 import { TodoView } from './todoview.component';
-import { RenderCounter } from './counter.component';
 import { ObservableTodoStore } from '../state/todos.state';
 import { TodoItem } from '../state/todo-item.state';
 
+interface Props {
+  store?: ObservableTodoStore;
+}
+
 @inject("store")
 @observer
-class TodoList extends React.Component<any, any> {
-  constructor(props: any) {
-    super(props);
-  }
-
+class TodoList extends React.Component<Props, {}> {
   render() {
-    const store : ObservableTodoStore = this.props.store;
-    console.log(store);
+    const store = this.props.store;
     return (
       <div>
         <Devtools />

--- a/src/components/todoview.component.tsx
+++ b/src/components/todoview.component.tsx
@@ -2,16 +2,20 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 
 import { RenderCounter } from './counter.component';
+import { TodoItem } from '../state/todo-item.state';
 
+interface Props {
+  todo: TodoItem
+}
 @observer
-class TodoView extends React.Component<any, any> {
+class TodoView extends React.Component<Props, {}> {
   render() {
     const todo = this.props.todo;
     return (
       <li onDoubleClick={ this.onRename }>
         <input type='checkbox' checked={ todo.completed } onChange={ this.onToggleCompleted } />
         { todo.task }
-        { todo.assignee? <small>{ todo.assignee.name }</small>: null}
+        { todo.assignee? <small>{ todo.assignee }</small>: null}
         <RenderCounter counter={ todo.counter } />
       </li>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,12 +3,11 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'mobx-react';
 
-// Import the Hot Module Reloading App Container – more on why we use 'require' below
-const { AppContainer } = require('react-hot-loader');
-
 // Import our App container (which we will create in the next step)
 import { App } from './components/App';
 import { todoStore } from './state/todos.state';
+import load from './load';
+load(todoStore);
 
 // Tell Typescript that there is a global variable called module - see below
 declare var module: { hot: any };
@@ -16,28 +15,26 @@ declare var module: { hot: any };
 // Get the root element from the HTML
 const rootEl = document.getElementById('app');
 
+const renderApp = (app: any) => {
+  render(
+      <Provider store={ todoStore }>
+        {app}
+      </Provider>,
+    rootEl
+  );
+};
+
+renderApp(<App/>); 
+
 // And render our App into it, inside the HMR App ontainer which handles the hot reloading
-render(
-  <AppContainer>
-    <Provider store={ todoStore }>
-      <App />
-    </Provider>
-  </AppContainer>,
-  rootEl
-);
 
 // Handle hot reloading requests from Webpack
 if (module.hot) {
   module.hot.accept('./components/App', () => {
     // If we receive a HMR request for our App container, then reload it using require (we can't do this dynamically with import)
-    const NextApp = require('./components/App').default;
+    const NextApp = require('./components/App').App;
 
     // And render it into the root element again
-    render(
-      <AppContainer>
-         <NextApp />
-      </AppContainer>,
-      rootEl
-    );
+    renderApp(<NextApp/>);
   })
 }

--- a/src/state/todos.state.tsx
+++ b/src/state/todos.state.tsx
@@ -1,7 +1,6 @@
 import * as mobx from 'mobx';
 import { observable, computed, action } from 'mobx';
 
-import { Counter } from './counter.state';
 import { TodoItem } from './todo-item.state';
 
 class ObservableTodoStore {


### PR DESCRIPTION
Fix some hot reload issues
Add types for props
Remove unneeded react-hot-loader, this has lots of moving parts under the hood that we don't need if we have state in one place and handle the webpack hot reload event ourselves (like we are already doing)